### PR TITLE
Support qlot

### DIFF
--- a/lib/swank-starter.coffee
+++ b/lib/swank-starter.coffee
@@ -15,7 +15,14 @@ class SwankStarter
       return false
     command = @lisp
     args = []
-    args.push 'run' if command.match(/ros/)
+    if command.match(/qlot/) # qlot exec ros -S . run @swank_script
+      args.push 'exec'
+      args.push 'ros'
+      args.push '-S'
+      args.push '.'
+      args.push 'run'
+    else if command.match(/ros/) # ros run @swank_script
+      args.push 'run'
     if not command.match(/clisp|lw/)
       args.push '--load'
     else


### PR DESCRIPTION
Eitaro Fukamachi's [`qlot`](https://github.com/fukamachi/qlot) is a project local library manager for Common Lisp.

Think of Python's virtualenv or Ruby's Bundler.

I use Qlot with Roswell. Therefor, if you configure the Lisp Process as `qlot` instead of `ros`, Roswell is still used because my commit expands `qlot` to `qlot exec ros -S . run`. `ros` is still expanded to `ros run`.